### PR TITLE
Ensure deploy:release is called on symlink deploys

### DIFF
--- a/recipe/mage.php
+++ b/recipe/mage.php
@@ -35,6 +35,7 @@ desc('Deploy release to sonassi server');
 task('sonassi', [
     'deploy:prepare',
     'deploy:lock',
+    'deploy:release',
     'deploy:zip:upload',
     'deploy:zip:unzip',
     'deploy:unlock',


### PR DESCRIPTION
With the latest refactors, `deploy:release` was removed I assume by accident as it's a required step for symlink based deployments. 

I've just simply added it back in 