### PR TITLE
Add task to do symlinks in the build

### DIFF
--- a/recipe/config.php
+++ b/recipe/config.php
@@ -8,6 +8,10 @@ set('locales', ['en_GB', 'en_US']);
 
 set('composer_options', '-o --no-dev --prefer-dist');
 
+// Key, Value = Source, Destination
+// E.g ['.' => 'pub/eu'] to symlink pub to pub/eu for multistore
+set('symlinks', []);
+
 set('shared_files', [
    'app/etc/env.php'
 ]);

--- a/recipe/custom/symlinks.php
+++ b/recipe/custom/symlinks.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Deployer;
+
+desc('Create symlinks defined by configuration');
+task('symlinks:local:create', function () {
+    /** @var array $symlinks */
+    $symlinks = get('symlinks');
+
+    foreach ($symlinks as $src => $dest) {
+        runLocally(sprintf('ln -sf %s %s', $src, $dest));
+    }
+});

--- a/recipe/mage.php
+++ b/recipe/mage.php
@@ -18,12 +18,14 @@ require __DIR__ . '/custom/magentoInstall.php';
 require __DIR__ . '/custom/composer.php';
 require __DIR__ . '/custom/ssh.php';
 require __DIR__ . '/custom/akoova.php';
+require __DIR__ . '/custom/symlinks.php';
 
 desc('Build Magento 2 production assets');
 task('build', [
     'composer:local:install',
     'magento:local:setup:static-content:deploy',
-    'magento:local:setup:di:compile'
+    'magento:local:setup:di:compile',
+    'symlinks:local:create'
 ]);
 
 desc('Bundle Magento 2 into tarball');


### PR DESCRIPTION
This adds a simple symlink task into the build process. 

It allows for the configuration to be set on the project level and can be any src and dest as long as you know how the `ln` command works 😄 

I've tested this locally by creating the build env with this branch, running it with JML locally and running the task. It successfully creates the symlink required with the configuration below on the `deploy.php` file

```php
set('symlinks', [
    '.' => 'pub/eu'
]);
```