### PR TITLE
make akoova deploy wait time configurable

### DIFF
--- a/recipe/custom/akoova.php
+++ b/recipe/custom/akoova.php
@@ -42,11 +42,9 @@ task('akoova:trigger:rollback', function () {
     run('touch {{ deploy_path }}/rollback-' . $rollbackTag);
 });
 
-set('deploy_status_wait', 180);
-
 desc('Poll for deployment status');
 task('akoova:deploy:status', function () {
-    $wait = get('deploy_status_wait');
+    $wait = get('deploy_status_wait', 180);
     $time = time();
 
     while (time() - $time < $wait) {


### PR DESCRIPTION
Second parameter is the default value according to: https://deployer.org/docs/api.html#get

This change means we can override this value in project's deploy.php.

On Selco this process is taking longer than 180, and we want to increase it.