### PR TITLE
Remove process timeout limit

### DIFF
--- a/recipe/config.php
+++ b/recipe/config.php
@@ -63,6 +63,8 @@ set('build_exclusions', [
     './node_modules'
 ]);
 
+set('default_timeout', null); //foreverrrrrr
+
 set('local_bin/php', function () {
     return runLocally('which php');
 });


### PR DESCRIPTION
A `Null` timeout means no timeout, since it uses Symfony process

Default 300 limit comes from: https://github.com/deployphp/deployer/blob/master/src/Component/Ssh/Client.php#L36

So unless there is a default, or a value passed in to the run function/set on the host, then 300 will be used.

Config does an array_key_exists for `default_timeout` so we can set null:
https://github.com/deployphp/deployer/blob/master/src/Configuration/Configuration.php#L58-L62

