### PR TITLE
Allow the exclusion of Magento themes

### DIFF
--- a/recipe/config.php
+++ b/recipe/config.php
@@ -5,6 +5,7 @@ namespace Deployer;
 set('local_src', '/root/build');
 
 set('locales', ['en_GB', 'en_US']);
+set('themes_to_exclude', []);
 
 set('composer_options', '-o --no-dev --prefer-dist');
 

--- a/recipe/custom/magento2.php
+++ b/recipe/custom/magento2.php
@@ -7,9 +7,14 @@ namespace Deployer;
 desc('Local deploy static assets');
 task('magento:local:setup:static-content:deploy', function () {
     $locales = get('locales') ?: [];
+    $excludeThemes = array_map(function ($theme) {
+        return "--exclude-theme $theme";
+    }, get('themes_to_exclude') ?: []);
+
     runLocally(sprintf(
-        '{{local_bin/php}} {{local_src}}/bin/magento setup:static-content:deploy -f %s',
-        implode(' ', $locales)
+        '{{local_bin/php}} {{local_src}}/bin/magento setup:static-content:deploy -f %s %s',
+        implode(' ', $locales),
+        implode(' ', $excludeThemes)
     ));
 });
 


### PR DESCRIPTION
It allows devs to define a list of themes that will be excluded when deploying static content as part of the project build process in CI. These themes to exclude can be defined in any project's deployer.php file as follows:

`set('themes_to_exclude', ['Magento/blank', 'Magento/luma']);`