### PR TITLE
- added optimized dump-autoload after di:compile to make sure that it contains dynamically generated classes

### DIFF
--- a/recipe/custom/magento2.php
+++ b/recipe/custom/magento2.php
@@ -20,7 +20,7 @@ task('magento:local:setup:static-content:deploy', function () {
 
 desc('Local DI compile');
 task('magento:local:setup:di:compile', function () {
-    runLocally('{{local_bin/php}} {{local_src}}/bin/magento setup:di:compile');
+    runLocally('{{local_bin/php}} {{local_src}}/bin/magento setup:di:compile && {{local_bin/composer}} dump-autoload -o --apcu');
 });
 
 // Remote commands


### PR DESCRIPTION
Currently, Magento recipe does not run `composer dump-autoload` after `setup:di:compile`.

This means that all classes generated dynamically by Magento DI are not included in composer classmap and all references to those classes during runtime generate performance degradation caused by excessive file_exists calls. 

Running `dump-autoload` after `di:compile` is recommended by official docs:

https://experienceleague.adobe.com/en/docs/commerce-operations/performance-best-practices/deployment-flow#preprocess-dependency-injection-instructions

and also included in the default deployer recipe maintained by the community:

https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L169

Hence I propose adding it in the default recipe. I tested it directly on one of the projects, giving 20-40ms performance gain on average request.