### PR TITLE
Fix deployer issue for woodies

### DIFF
--- a/recipe/custom/prepare.php
+++ b/recipe/custom/prepare.php
@@ -7,8 +7,6 @@
 
 namespace Deployer;
 
-use function Deployer\Support\str_contains;
-
 try {
     Deployer::get()->tasks->remove('deploy:prepare');
 } catch (\InvalidArgumentException $e) {


### PR DESCRIPTION
As we're getting this error: https://app.circleci.com/pipelines/github/WeareJH/woodies/4795/workflows/1cb9d7d1-1831-4955-a4bb-eac70a65ae73/jobs/17866

I have remove `Deployer\Support\str_contains()`. Since the server runs PHP 8.2, PHP's native str_contains() is available globally.
 `str_contains` calls on lines 24 and 24 will just use the native PHP function automatically.